### PR TITLE
Stopped the cart button for acting like a filter

### DIFF
--- a/Project/restaurantSite/menuPage/static/js/index.js
+++ b/Project/restaurantSite/menuPage/static/js/index.js
@@ -192,7 +192,8 @@
         // prevent default behavior of the anchor tag
         event.preventDefault();
         //Only do this if the <a> tags are clicked
-        if (!$(event.target).is("a")) {
+        console.log($(event.target).hasClass("navBarSort"))
+        if ($(event.target).hasClass("navBarSort") || !$(event.target).is("a")) {
             return
         }
         //Get clicked item


### PR DESCRIPTION
- The cart button was acting as a filter if it was clicked before any other filter
- Made the filter ignore the cart button.